### PR TITLE
logging cleanup

### DIFF
--- a/webauthn2/providers/globus_auth.py
+++ b/webauthn2/providers/globus_auth.py
@@ -86,12 +86,12 @@ class GlobusViewGroupTokenProcessor(GlobusGroupTokenProcessor):
                                            group_base_url if group_base_url else self.default_base_url)
 
     def get_groups(self):
-        web.debug("trying view_my_groups, token is {t}".format(t=str(self.token)))
+ #       web.debug("trying view_my_groups, token is {t}".format(t=str(self.token)))
         final_groups = set()
         if self.token != None:
             group_request = urllib.request.Request(self.group_base_url)
             raw_groups = self.get_raw_groups(group_request)
-            web.debug("raw_groups is {r}".format(r=raw_groups))
+#            web.debug("raw_groups is {r}".format(r=raw_groups))
             
             for g in raw_groups:
                 # Unlike the old API, this will only return
@@ -117,8 +117,8 @@ class GlobusLegacyGroupTokenProcessor(GlobusGroupTokenProcessor):
         }
 
     def get_groups(self):
-        web.debug("Using legacy Globus group processor")
-        web.debug("trying group request, token is {t}".format(t=str(self.token)))        
+#        web.debug("Using legacy Globus group processor")
+#        web.debug("trying group request, token is {t}".format(t=str(self.token)))
         final_groups = set()
         if self.token != None:
             urltuple = urllib.parse.urlsplit(self.group_base_url)
@@ -181,7 +181,7 @@ class GlobusAuthLogin(oauth2.OAuth2Login):
                             processor.set_token(token)
                             group_token_processor = processor
                     
-        web.debug("wallet: " + str(context.wallet))
+#        web.debug("wallet: " + str(context.wallet))
         web.debug("token processor: " + str(group_token_processor))
         if group_token_processor is not None:
             context.globus_groups = group_token_processor.get_groups()
@@ -192,7 +192,7 @@ class GlobusAuthLogin(oauth2.OAuth2Login):
 
     def add_extra_token_request_headers(self, token_request):
         client_id = self.provider.cfg.get('client_id')
-        web.debug("client id is {i}".format(i=client_id))
+#        web.debug("client id is {i}".format(i=client_id))
         client_secret = self.provider.cfg.get('client_secret')
         basic_auth_token = base64.b64encode((client_id + ':' + client_secret).encode())
         token_request.add_header('Authorization', 'Basic ' + basic_auth_token.decode())
@@ -208,7 +208,7 @@ class GlobusAuthLogin(oauth2.OAuth2Login):
             client = globus_sdk.ConfidentialAppAuthClient(self.provider.cfg.get('client_id'), self.provider.cfg.get('client_secret'))            
             # attempt to get dependent tokens
             try:
-                introspect_response = client.oauth2_token_introspect(bearer_token)
+#                introspect_response = client.oauth2_token_introspect(bearer_token)
                 token_response = client.oauth2_get_dependent_tokens(bearer_token).data
                 if token_response != None and len(token_response) > 0:
                     self.payload['dependent_tokens_source'] = client.base_url

--- a/webauthn2/providers/oauth2.py
+++ b/webauthn2/providers/oauth2.py
@@ -434,7 +434,7 @@ class OAuth2Login (ClientLogin):
         # This is called within db_wrapper, which will retry if it gets
         # a urllib.request.HTTPError
         try:
-            web.debug("before urlopen")
+#            web.debug("before urlopen")
             return urllib.request.urlopen(req)
         except Exception as ev:
             web.debug("urlopen exception {e}".format(e=str(ev)))


### PR DESCRIPTION
Clean up various web.debug() statements that generate quite a bit of log output.

Remove an extra oauth2_token_introspect call that was not needed.