### PR TITLE
Update dependencies to make the build pass

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
           sudo pip3 install globus_sdk
           sudo pip3 install psycopg2-binary
           sudo pip3 install oauth2client
+          sudo pip3 install pyjwkest
           sudo useradd -m -r webauthn
           sudo su -c '/usr/bin/python3 -c "import sys;import pprint;pprint.pprint(sys.path)"' - webauthn
       - name: Install webauthn

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 
 name: Webauthn tests
 
-on: 
+on:
   push:
-    branches: 
+    branches:
       - 'master'
   pull_request:
     branches:
@@ -32,14 +32,19 @@ jobs:
           sudo ln -s /etc/apache2/conf-enabled /etc/apache2/conf.d
           sudo a2enmod ssl
           sudo a2ensite default-ssl
-          sudo groupadd -o -g $(id -g www-data) apache 
+          sudo groupadd -o -g $(id -g www-data) apache
           sudo apt-get install -y python3-setuptools python3-ply
           sudo pip3 --version
           sudo su -c 'echo /usr/lib/python3.8/site-packages > /usr/local/lib/python3.8/dist-packages/sys-site-packages.pth'
           sudo su -c 'python3 -c "import site;print(site.PREFIXES);"'
           sudo su -c 'python3 -c "import site;print(site.getsitepackages())"'
-          sudo pip3 install psycopg2-binary
+          : # the line below will make sure pyopenssl and cryptography have compatible versions
+          sudo pip3 install -U pyopenssl cryptography
           sudo pip3 install flask
+          sudo pip3 install requests
+          sudo pip3 install globus_sdk
+          sudo pip3 install psycopg2-binary
+          sudo pip3 install oauth2client
           sudo useradd -m -r webauthn
           sudo su -c '/usr/bin/python3 -c "import sys;import pprint;pprint.pprint(sys.path)"' - webauthn
       - name: Install webauthn
@@ -87,4 +92,4 @@ jobs:
           sudo cat ${HTTPD_ERROR_LOG}
           sudo cat /var/log/apache2/access.log
           sudo cat /tmp/robot123cred.json
-                    
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,7 @@ jobs:
           sudo su -c 'python3 -c "import site;print(site.getsitepackages())"'
           : # the line below will make sure pyopenssl and cryptography have compatible versions
           sudo pip3 install -U pyopenssl cryptography
+          sudo pip3 install pycryptodome
           sudo pip3 install flask
           sudo pip3 install requests
           sudo pip3 install globus_sdk


### PR DESCRIPTION
After adding the missing dependencies, Actions was throwing this error during installation:

```
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
``` 

So I had to add the following line (borrowed from [here](https://stackoverflow.com/questions/74981558/error-updating-python3-pip-attributeerror-module-lib-has-no-attribute-openss)):
```
sudo pip3 install -U pyopenssl cryptography
```

Not sure if this the best way to install dependencies or not.

With these changes the installation goes smoothly, so I [applied them to ermrestjs case](https://github.com/informatics-isi-edu/ermrestjs/pull/987) and the test cases in that repo are passing. But the test cases for webauthn are failing and I don't know much about this repository to be able to figure out why.