### PR TITLE
add util.ClientSessionCachedProxy class

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     requires=[
         "flask",
         "psycopg2",
+        "cachetools",
         "oauth",
         "oauth2client",
         "pyjwkest",
@@ -54,6 +55,7 @@ setup(
     install_requires=[
         "flask",
         "psycopg2",
+        "cachetools",
         "oauth",
         "oauth2client",
         "pyjwkest",


### PR DESCRIPTION
To function without mod_webauthn assistance, a service can instantiate a stateful (caching) proxy:

  proxy = ClientSessionCachedProxy(config=None)

and then determine per-request context with:

  context = proxy.get_context(environ, cookies)

if mod_webauthn state is detected in the environ, the existing context_from_environment() mechanism will be used. otherwise, a proxy call to /authn/session will be made via the requests library with results cached using a TTL and LRU cache eviction scheme.